### PR TITLE
Fix repo resolution

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:$COMMIT_SHA', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:$COMMIT_SHA' ]
-- name: 'gcr.io/$PROJECT_ID/kubernetes-deploy-builder:latest'
-  args: ['gcb-notifier', 'gke_amcleodca-fuzz_northamerica-northeast1-c_hp48g' ]
-  env:
-  - 'CLOUDSDK_CONTAINER_CLUSTER=hp48g'
-  - 'CLOUDSDK_COMPUTE_ZONE=northamerica-northeast1-c'
-  - 'REVISION=$COMMIT_SHA'
-  - 'ENVIRONMENT=production'
-  - 'KUBECONFIG=.kube/config'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:$COMMIT_SHA',
+                  '-t', 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:latest',
+                  '.']
+images:
+- 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gcb-notifier/gcb-notifier:latest'


### PR DESCRIPTION
The original implementation tried to determine the name of the github repo by parsing the name of the google source repo. This was a wrong approach. We should get the github repo config from the source repo's configuration.